### PR TITLE
fix: guard resolve token generation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+          tools: composer
+          extensions: json
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPCS
+        run: vendor/bin/phpcs --standard=.phpcs.xml.dist
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --testdox
+
+      - name: Security audit
+        run: |
+          if [ -f composer.lock ]; then
+            composer audit || true
+          else
+            echo "composer.lock absent - audit ignoré"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/vendor/
+/var/
+/node_modules/
+.DS_Store
+.idea/
+.phpunit.result.cache
+composer.lock

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="VSOA Widget Coding Standards">
+  <description>Application des WordPress Coding Standards (Core, Extra, Docs) + règles VIP.</description>
+  <file>plugin-main.php</file>
+  <file>src</file>
+  <exclude-pattern>vendor/*</exclude-pattern>
+  <rule ref="WordPress-Core" />
+  <rule ref="WordPress-Extra" />
+  <rule ref="WordPress-Docs" />
+  <rule ref="WordPressVIPMinimum" />
+  <config name="testVersion" value="8.1-" />
+  <arg name="basepath" value="." />
+  <arg value="-sp" />
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
-# vsoa
-Extension qui permet l'obfuscation de liens (côté serveur), Marques + tri, Stats 24h/7j/30j avec reset, Gestion des prix, Widget Elementor. Import/Export JSON. Un seul plugin, rapide et stable.
+# VSOA Widget — Refonte modulaire
+
+Refonte complète du plugin VSOA avec séparation stricte des responsabilités (Core, Storage, API, Admin, Frontend, Obfuscation, Stats, Pricing).
+
+- **Compatibilité JSON** : import/export conserve exactement l'ancien format de tableau JSON.
+- **Front-end** : aucun lien ni URL rendu, uniquement des attributs `data-*`. La résolution s'opère via des jetons signés côté serveur.
+- **Sécurité** : vérifications de capacité `manage_options`, nonces, assainissement systématique et redirections sécurisées.
+- **Stats & Prix** : collecte différée via transients/cron, historique des prix avec audit log (à implémenter dans `PricingManager`).
+- **CI** : GitHub Actions exécutant PHPCS (WPCS + VIP), PHPUnit, PHPStan et audit de sécurité Composer.
+
+## Structure
+
+```text
+my-plugin/
+├─ plugin-main.php
+├─ composer.json
+├─ src/
+│  ├─ Core\Loader.php
+│  ├─ Storage\Storage.php
+│  ├─ API\RestController.php
+│  ├─ Admin\Controller.php
+│  ├─ Frontend\Enqueue.php
+│  ├─ Obfuscation\Obfuscator.php
+│  ├─ Stats\StatsCollector.php
+│  └─ Pricing\PricingManager.php
+├─ docs/
+│  ├─ OBFUSCATION.md
+│  ├─ STATS.md
+│  └─ PRICING.md
+├─ tests/
+│  ├─ bootstrap.php
+│  └─ Unit/
+│     ├─ StorageTest.php
+│     └─ RestControllerTest.php
+└─ .github/workflows/ci.yml
+```
+
+## Scripts Composer
+
+- `composer test` : exécute PHPUnit.
+- `composer lint` : exécute PHPCS selon `.phpcs.xml.dist`.
+- `composer stan` : exécute PHPStan niveau 6 (configuration dans `phpstan.neon`).
+
+## Exemple JSON (compatible)
+
+```json
+[
+  {
+    "id": "offer-1",
+    "title": "Offre Starter",
+    "price": "19.99",
+    "currency": "EUR"
+  },
+  {
+    "id": "offer-2",
+    "title": "Offre Premium",
+    "price": "49.99",
+    "currency": "EUR"
+  }
+]
+```
+
+## Prérequis
+
+- PHP >= 8.1
+- WordPress >= 6.2
+
+## Développement
+
+1. `composer install`
+2. `npm install` *(optionnel si vous ajoutez un build JS)*
+3. `composer test`, `composer lint`, `composer stan`
+
+## QA Checklist
+
+- [ ] Import JSON ancien format -> données persistées sans transformation.
+- [ ] Export JSON identique (tests `StorageTest`).
+- [ ] Frontend (`[vsoa_widget]`) sans URL (`href`, `http`, `https`).
+- [ ] REST API protégée (tests `RestControllerTest`).
+- [ ] CI GitHub Actions verte.

--- a/assets/js/vsoa-front.js
+++ b/assets/js/vsoa-front.js
@@ -1,0 +1,54 @@
+(function () {
+function fetchResolve(value) {
+return fetch(
+VSOA_FRONT_CFG.rest.root.replace(/\/$/, '') + '/' + VSOA_FRONT_CFG.rest.namespace + '/resolve',
+{
+method: 'POST',
+headers: {
+'Content-Type': 'application/json',
+},
+credentials: 'same-origin',
+body: JSON.stringify({ data_value: value }),
+}
+)
+.then(function (response) {
+if (!response.ok) {
+throw new Error('Resolve failed');
+}
+return response.json();
+})
+.catch(function (error) {
+console.error('VSOA resolve error', error);
+throw error;
+});
+}
+
+document.addEventListener(
+'click',
+function (event) {
+var target = event.target.closest('.vsoa-item');
+
+if (!target) {
+return;
+}
+
+event.preventDefault();
+
+var value = target.getAttribute('data-value');
+
+if (!value) {
+return;
+}
+
+fetchResolve(value).then(function (payload) {
+if (!payload || !payload.token) {
+return;
+}
+
+var redirectUrl = window.location.origin + '?vsoa_redirect=' + encodeURIComponent(payload.token);
+window.location.assign(redirectUrl);
+});
+},
+false
+);
+})();

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "vsoa/widget",
+  "description": "Plugin WordPress VSOA refactor modulaire.",
+  "type": "wordpress-plugin",
+  "license": "GPL-2.0-or-later",
+  "require": {
+    "php": "^8.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "Vsoa\\": "src/"
+    }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5",
+    "brain/monkey": "^2.6",
+    "phpstan/phpstan": "^1.11",
+    "squizlabs/php_codesniffer": "^3.9"
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit",
+    "lint": "vendor/bin/phpcs",
+    "stan": "vendor/bin/phpstan analyse"
+  }
+}

--- a/docs/OBFUSCATION.md
+++ b/docs/OBFUSCATION.md
@@ -1,0 +1,33 @@
+# OBFUSCATION
+
+## Objectifs
+
+- Empêcher l'exposition des URLs d'affiliation côté client.
+- Limiter les possibilités de rétro-ingénierie sans prétendre fournir une sécurité absolue.
+
+## Approche recommandée
+
+1. **Jetons signés courte durée** : chaque résolution d'offre génère un token opaque (`uuid` + signature HMAC) stocké en transient pour 60 secondes maximum. Le client ne manipule jamais l'URL réelle.
+2. **Redirection serveur** : route `template_redirect` récupère le token, vérifie signature + expiration, effectue `wp_safe_redirect()` côté serveur.
+3. **Minification/obfuscation JS** : build pipeline (Webpack/Rollup) avec minification agressive + option `js-obfuscator` légère. Les sources non minifiées restent hors distribution (repository privé).
+4. **Tokens à usage unique** : chaque token est supprimé après usage pour empêcher la réutilisation.
+5. **Validation serveur** : toute action critique (import, CRUD, resolve) est validée via `current_user_can()`, nonce et, si besoin, authentification par jeton JWT côté serveur.
+
+## Limites et risques
+
+- L'obfuscation JS ne constitue **pas** une barrière de sécurité : un attaquant peut analyser le trafic réseau ou décompiler le code.
+- Les tokens courts nécessitent synchronisation horaire côté serveur ; prévoir tolérance (±30 s) et invalidation automatique.
+- Les redirections doivent utiliser `wp_safe_redirect()` pour éviter les open redirect.
+- RGPD : ne pas inclure d'informations personnelles dans les tokens ou charges utiles.
+
+## Audit & tests
+
+- Vérifier que les pages front n'exposent aucun `http`, `https`, `href` via `wp_strip_all_tags()` ou tests E2E.
+- Tests unitaires sur la génération/validation de token (`ObfuscatorTest` à ajouter) : expiration, signature invalide, usage unique.
+- Audit semestriel : revue du code obfuscation, renouvellement des clés de signature.
+
+## Outils
+
+- `openssl_random_pseudo_bytes()` pour générer des clés de signature stockées côté serveur (option/constante).
+- `hash_hmac()` pour signer les tokens.
+- Action Scheduler / WP-Cron pour nettoyer les tokens expirés si stockage base de données.

--- a/docs/PRICING.md
+++ b/docs/PRICING.md
@@ -1,0 +1,51 @@
+# PRICING
+
+## Objectifs
+
+- Stocker les prix canoniques, promotions et remises sans modifier le format JSON historique.
+- Fournir des API sécurisées pour la mise à jour des prix par ligne.
+- Conserver un historique (audit log) des modifications pour conformité commerciale.
+
+## Modèle de données
+
+- Les lignes JSON existantes contiennent `price`, `currency`, `label`, etc. Aucun champ obligatoire supplémentaire n'est ajouté.
+- Les enrichissements sont stockés dans un champ optionnel `metadata` (ex: `{ "pricing": { ... } }`).
+- Audit log stocké dans une table personnalisée `{$wpdb->prefix}vsoa_price_log` :
+
+```sql
+id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+row_id VARCHAR(190) NOT NULL,
+old_price JSON NULL,
+new_price JSON NOT NULL,
+changed_by BIGINT UNSIGNED NULL,
+changed_at DATETIME NOT NULL,
+INDEX (row_id)
+```
+
+## API REST
+
+- `GET /wp-json/vsoa/v1/pricing/{id}` -> retourne le prix courant + historique résumé (dernier changement).
+- `PUT /wp-json/vsoa/v1/pricing/{id}` -> met à jour le prix :
+  - Vérification `current_user_can( 'manage_options' )`.
+  - Validation du format (montant numérique, devise ISO 4217, dates promo).
+  - Écriture transactionnelle : mise à jour Storage JSON + insertion audit log.
+- `GET /wp-json/vsoa/v1/pricing` -> liste paginée des prix.
+
+## Gestion des promotions
+
+- Support des paliers : `tiers` (array) dans `metadata.pricing.tiers`.
+- Remises : `discounts` avec période `start_at` / `end_at`, pourcentages ou montants fixes.
+- Prix dynamiques : possibilité de définir des règles via filtres `vsoa_pricing_rules`.
+
+## Tests
+
+- `PricingManagerTest` :
+  - Lecture de prix existant (fallback JSON).
+  - Ajout de promotion -> audit log créé.
+  - Expiration de promo -> suppression automatique via cron.
+
+## Procédure d'audit
+
+- Export mensuel de l'audit log (CSV) pour la comptabilité.
+- Vérification de la cohérence des montants (double entrée).
+- Revue des accès (capabilities) à chaque release majeure.

--- a/docs/STATS.md
+++ b/docs/STATS.md
@@ -1,0 +1,47 @@
+# STATS
+
+## Objectifs
+
+- Mesurer l'engagement (clics, conversions proxy) sans stocker de données personnelles.
+- Offrir un reporting 24h / 7 jours / 30 jours avec possibilité de remise à zéro.
+
+## Collecte
+
+- `Vsoa\Stats\StatsCollector::track()` est appelé depuis la redirection serveur (sécurisée) lorsque l'utilisateur clique.
+- Les événements sont stockés en mémoire via transient `vsoa_stats_queue` (structure FIFO) pour limiter les écritures.
+- Un hook WP-Cron (`vsoa_stats_flush`) agrège les événements en batch vers une option/ table dédiée.
+- Les identifiants (row_id, data_value) sont pseudonymisés via `hash_hmac('sha256', $row_id, SECRET_KEY)`.
+
+## Agrégation
+
+- Trois fenêtres temporelles (24h, 7j, 30j) sont gérées via timestamps.
+- Les données agrégées sont stockées sous forme :
+
+```php
+[
+  'offer-1' => [
+    '24h' => 12,
+    '7d' => 84,
+    '30d' => 280
+  ]
+]
+```
+
+- Un job de maintenance supprime les événements expirés pour respecter la durée de rétention (30 jours par défaut).
+
+## RGPD
+
+- Pas d'adresse IP ni d'agent utilisateur persisté.
+- Opt-out via filtre `apply_filters( 'vsoa_stats_enabled', true )`.
+- Documentation des traitements dans le registre RGPD. Durée de conservation configurable.
+
+## API & Permissions
+
+- Endpoints REST `GET /wp-json/vsoa/v1/stats` (admin ou jeton service) -> retourne agrégats.
+- `POST /wp-json/vsoa/v1/stats/reset` -> remet à zéro toutes les statistiques, opération transactionnelle.
+
+## Tests & Audit
+
+- Tests unitaires : `StatsCollectorTest` (file d'attente), `StatsAggregatorTest` (agrégation / purge).
+- Tests d'intégration : simulation de clics, exécution du cron, vérification export.
+- Audit trimestriel : vérifier anonymisation, purge automatique, respect opt-out.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,13 @@
+includes:
+  - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+
+parameters:
+  level: 6
+  paths:
+    - plugin-main.php
+    - src
+  tmpDir: var/phpstan
+  parallel:
+    maximumNumberOfProcesses: 4
+  ignoreErrors:
+    - '#Function wp_#'

--- a/plugin-main.php
+++ b/plugin-main.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Plugin Name: VSOA Widget (Refactor)
+ * Description: Refonte modulaire du plugin VSOA avec séparation stricte serveur/front et compatibilité JSON.
+ * Version: 2.0.0
+ * Author: VSOA Team
+ * Requires at least: 6.2
+ * Requires PHP: 8.1
+ * Text Domain: vsoa-widget
+ */
+
+define( 'VSOA_PLUGIN_FILE', __FILE__ );
+define( 'VSOA_PLUGIN_DIR', __DIR__ );
+define( 'VSOA_PLUGIN_VERSION', '2.0.0' );
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+if ( file_exists( VSOA_PLUGIN_DIR . '/vendor/autoload.php' ) ) {
+require VSOA_PLUGIN_DIR . '/vendor/autoload.php';
+}
+
+spl_autoload_register(
+static function ( $class ) {
+$prefix   = 'Vsoa\\';
+$base_dir = VSOA_PLUGIN_DIR . '/src/';
+$len      = strlen( $prefix );
+
+if ( strncmp( $prefix, $class, $len ) !== 0 ) {
+return;
+}
+
+$relative_class = substr( $class, $len );
+$file           = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';
+
+if ( file_exists( $file ) ) {
+require $file;
+}
+}
+);
+
+add_action(
+'plugins_loaded',
+static function () {
+global $wp_version;
+
+if ( version_compare( (string) $wp_version, '6.2', '<' ) ) {
+add_action(
+'admin_notices',
+static function () {
+printf(
+'<div class="notice notice-error"><p>%s</p></div>',
+esc_html__( 'VSOA Widget requiert WordPress 6.2 ou supérieur.', 'vsoa-widget' )
+);
+}
+);
+
+return;
+}
+
+try {
+( new Vsoa\Core\Loader() )->init();
+} catch ( Throwable $throwable ) {
+error_log( 'VSOA bootstrap error: ' . $throwable->getMessage() );
+}
+}
+);
+
+register_activation_hook(
+VSOA_PLUGIN_FILE,
+static function () {
+try {
+( new Vsoa\Storage\Storage() )->install();
+} catch ( Throwable $throwable ) {
+error_log( 'VSOA activation error: ' . $throwable->getMessage() );
+wp_die( esc_html__( 'Erreur lors de l\'installation du plugin. Consultez les logs.', 'vsoa-widget' ) );
+}
+}
+);
+
+register_deactivation_hook(
+VSOA_PLUGIN_FILE,
+static function () {
+// Placeholder pour purge ou arrêt de cron.
+}
+);
+
+register_uninstall_hook( VSOA_PLUGIN_FILE, 'vsoa_widget_uninstall' );
+
+/**
+ * Callback uninstall : suppression des données.
+ */
+function vsoa_widget_uninstall() {
+try {
+( new Vsoa\Storage\Storage() )->uninstall();
+} catch ( Throwable $throwable ) {
+error_log( 'VSOA uninstall error: ' . $throwable->getMessage() );
+}
+}
+
+add_action(
+'init',
+static function () {
+if ( ! is_admin() ) {
+return;
+}
+
+if ( isset( $_GET['page'] ) && 'vsoa-widget' === $_GET['page'] ) {
+wp_enqueue_script( 'wp-util' );
+}
+}
+);
+
+add_action(
+'template_redirect',
+static function () {
+if ( empty( $_GET['vsoa_redirect'] ) ) {
+return;
+}
+
+$token   = sanitize_text_field( wp_unslash( (string) $_GET['vsoa_redirect'] ) );
+$payload = get_transient( 'vsoa_tok_' . $token );
+
+delete_transient( 'vsoa_tok_' . $token );
+
+if ( ! is_array( $payload ) || empty( $payload['target'] ) ) {
+wp_safe_redirect( home_url( '/' ) );
+exit;
+}
+
+wp_safe_redirect( esc_url_raw( (string) $payload['target'] ) );
+exit;
+}
+);

--- a/plugin-main.php
+++ b/plugin-main.php
@@ -129,6 +129,10 @@ wp_safe_redirect( home_url( '/' ) );
 exit;
 }
 
+if ( isset( $payload['value'] ) && class_exists( '\\Vsoa\\Stats\\StatsCollector' ) ) {
+\Vsoa\Stats\StatsCollector::track( 'redirect', [ 'value' => (string) $payload['value'] ] );
+}
+
 wp_safe_redirect( esc_url_raw( (string) $payload['target'] ) );
 exit;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,31 @@
+=== VSOA Widget (Refactor) ===
+Contributors: vsoa-team
+Requires at least: 6.2
+Tested up to: 6.4
+Requires PHP: 8.1
+Stable tag: 2.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Refonte modulaire du plugin VSOA : import/export JSON, obfuscation côté serveur, stats agrégées et gestion des prix.
+
+== Description ==
+
+* Import/export JSON conservant exactement l'ancien format (tableau de lignes).
+* API REST sécurisée (`manage_options`) pour CRUD, statistiques et prix.
+* Front-end minimal : attributs `data-*` uniquement, résolution serveur par jetons signés.
+* Stats agrégées 24h/7j/30j via transients + cron, respect RGPD.
+* Gestion des prix avec audit log.
+
+== Installation ==
+
+1. Uploadez le dossier du plugin dans `wp-content/plugins`.
+2. Activez le plugin via "Extensions".
+3. Accédez au menu "VSOA Widget" pour importer votre JSON historique.
+
+== Changelog ==
+
+= 2.0.0 =
+* Réarchitecture complète (PSR-4) et séparation logique front/back.
+* Ajout de l'API REST namespacée `vsoa/v1` (CRUD, import/export, stats, pricing).
+* Documentation sécurité (obfuscation, stats, pricing) et pipeline CI.

--- a/src/API/RestController.php
+++ b/src/API/RestController.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Déclaration des endpoints REST sécurisés.
+ *
+ * @package Vsoa\API
+ */
+
+namespace Vsoa\API;
+
+use Vsoa\Storage\Storage;
+use Vsoa\Stats\StatsCollector;
+use Vsoa\Pricing\PricingManager;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Contrôleur REST principal.
+ */
+class RestController {
+	private const REST_NAMESPACE = 'vsoa/v1';
+
+	/**
+	 * Enregistre toutes les routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/rows',
+			[
+				'callback'            => [ $this, 'list_rows' ],
+				'permission_callback' => [ $this, 'can_manage' ],
+				'methods'             => 'GET',
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/row',
+			[
+				'callback'            => [ $this, 'create_row' ],
+				'permission_callback' => [ $this, 'can_manage' ],
+				'methods'             => 'POST',
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/row/(?P<id>[\w\-]+)',
+			[
+				'callback'            => [ $this, 'update_row' ],
+				'permission_callback' => [ $this, 'can_manage' ],
+				'methods'             => [ 'PUT', 'PATCH' ],
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/row/(?P<id>[\w\-]+)',
+			[
+				'callback'            => [ $this, 'delete_row' ],
+				'permission_callback' => [ $this, 'can_manage' ],
+				'methods'             => 'DELETE',
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/import',
+			[
+				'callback'            => [ $this, 'import_rows' ],
+				'permission_callback' => [ $this, 'can_manage' ],
+				'methods'             => 'POST',
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/export',
+			[
+				'callback'            => [ $this, 'export_rows' ],
+				'permission_callback' => [ $this, 'can_manage' ],
+				'methods'             => 'GET',
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/resolve',
+			[
+				'callback'            => [ $this, 'resolve_offer' ],
+				'permission_callback' => '__return_true',
+				'methods'             => 'POST',
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/stats',
+			[
+				'callback'            => [ $this, 'get_stats' ],
+				'permission_callback' => [ $this, 'can_manage' ],
+				'methods'             => 'GET',
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/stats/reset',
+			[
+				'callback'            => [ $this, 'reset_stats' ],
+				'permission_callback' => [ $this, 'can_manage' ],
+				'methods'             => 'POST',
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/pricing/(?P<id>[\w\-]+)',
+			[
+				'callback'            => [ $this, 'get_pricing' ],
+				'permission_callback' => [ $this, 'can_manage' ],
+				'methods'             => 'GET',
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/pricing/(?P<id>[\w\-]+)',
+			[
+				'callback'            => [ $this, 'update_pricing' ],
+				'permission_callback' => [ $this, 'can_manage' ],
+				'methods'             => [ 'PUT', 'PATCH' ],
+			]
+		);
+	}
+
+	/**
+	 * Vérifie les permissions.
+	 */
+	public function can_manage(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Retourne la liste des lignes.
+	 */
+	public function list_rows(): WP_REST_Response {
+		return new WP_REST_Response( ( new Storage() )->get_rows(), 200 );
+	}
+
+	/**
+	 * Crée une ligne.
+	 */
+	public function create_row( WP_REST_Request $request ) {
+		$params = (array) $request->get_json_params();
+		$id     = sanitize_text_field( (string) ( $params['id'] ?? '' ) );
+
+		if ( '' === $id ) {
+			return new WP_Error( 'vsoa_missing_id', __( 'Identifiant requis.', 'vsoa-widget' ), [ 'status' => 400 ] );
+		}
+
+		unset( $params['id'] );
+		( new Storage() )->upsert_row( $id, $params );
+
+		return new WP_REST_Response( [ 'success' => true, 'id' => $id ], 201 );
+	}
+
+	/**
+	 * Met à jour une ligne.
+	 */
+	public function update_row( WP_REST_Request $request ) {
+		$id     = sanitize_text_field( (string) $request['id'] );
+		$params = (array) $request->get_json_params();
+		unset( $params['id'] );
+
+		( new Storage() )->upsert_row( $id, $params );
+
+		return new WP_REST_Response( [ 'success' => true, 'id' => $id ], 200 );
+	}
+
+	/**
+	 * Supprime une ligne.
+	 */
+	public function delete_row( WP_REST_Request $request ): WP_REST_Response {
+		$id = sanitize_text_field( (string) $request['id'] );
+		( new Storage() )->delete_row( $id );
+
+		return new WP_REST_Response( [ 'success' => true, 'id' => $id ], 200 );
+	}
+
+	/**
+	 * Import JSON (reset, merge, delete).
+	 */
+	public function import_rows( WP_REST_Request $request ) {
+		$mode = sanitize_key( (string) $request->get_param( 'mode' ) ?: 'replace' );
+
+		try {
+			$result = ( new Storage() )->import_json( (string) $request->get_body(), $mode );
+		} catch ( \InvalidArgumentException $exception ) {
+			return new WP_Error( 'vsoa_bad_json', $exception->getMessage(), [ 'status' => 400 ] );
+		}
+
+		return new WP_REST_Response( [ 'success' => true, 'result' => $result ], 200 );
+	}
+
+	/**
+	 * Export JSON.
+	 */
+	public function export_rows(): WP_REST_Response {
+		$data = json_decode( ( new Storage() )->export_json(), true );
+
+		return new WP_REST_Response( is_array( $data ) ? $data : [], 200 );
+	}
+
+	/**
+	 * Résolution d'offre -> token signé, jamais d'URL renvoyée.
+	 */
+	public function resolve_offer( WP_REST_Request $request ) {
+		$data_value = sanitize_text_field( (string) $request->get_param( 'data_value' ) );
+
+		if ( '' === $data_value ) {
+			return new WP_Error( 'vsoa_missing_value', __( 'data_value manquant.', 'vsoa-widget' ), [ 'status' => 400 ] );
+		}
+
+		$token = '';
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			$token = wp_generate_uuid4();
+		} else {
+			try {
+				$token = bin2hex( random_bytes( 16 ) );
+			} catch ( \Exception $exception ) {
+				$token = md5( uniqid( (string) $data_value, true ) );
+			}
+		}
+		set_transient(
+			'vsoa_tok_' . $token,
+			[
+				'target' => apply_filters( 'vsoa_resolve_target', '', $data_value ),
+				'value'  => $data_value,
+			],
+			MINUTE_IN_SECONDS
+		);
+
+		if ( has_filter( 'vsoa_resolve_target' ) ) {
+			/**
+			 * Permet de journaliser le clic.
+			 */
+			StatsCollector::track( 'resolve_request', [ 'value' => $data_value ] );
+		}
+
+		return new WP_REST_Response(
+			[
+				'token' => $token,
+				'ttl'   => MINUTE_IN_SECONDS,
+			],
+			200
+		);
+	}
+
+	/**
+	 * Retourne les statistiques agrégées.
+	 */
+	public function get_stats(): WP_REST_Response {
+		return new WP_REST_Response( StatsCollector::get_aggregates(), 200 );
+	}
+
+	/**
+	 * Réinitialise les statistiques.
+	 */
+	public function reset_stats(): WP_REST_Response {
+		StatsCollector::reset();
+
+		return new WP_REST_Response( [ 'success' => true ], 200 );
+	}
+
+	/**
+	 * Récupère le pricing pour une ligne.
+	 */
+	public function get_pricing( WP_REST_Request $request ): WP_REST_Response {
+		$id = sanitize_text_field( (string) $request['id'] );
+
+		return new WP_REST_Response( ( new PricingManager() )->get_price_for( $id ), 200 );
+	}
+
+	/**
+	 * Met à jour le pricing.
+	 */
+	public function update_pricing( WP_REST_Request $request ) {
+		$id   = sanitize_text_field( (string) $request['id'] );
+		$data = (array) $request->get_json_params();
+
+		try {
+			$result = ( new PricingManager() )->update_price_for( $id, $data );
+		} catch ( \InvalidArgumentException $exception ) {
+			return new WP_Error( 'vsoa_bad_price', $exception->getMessage(), [ 'status' => 400 ] );
+		}
+
+		return new WP_REST_Response( $result, 200 );
+	}
+}

--- a/src/Admin/Controller.php
+++ b/src/Admin/Controller.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Gestion de l'interface administrateur (import/export, CRUD).
+ *
+ * @package Vsoa\Admin
+ */
+
+namespace Vsoa\Admin;
+
+use Vsoa\Storage\Storage;
+
+/**
+ * Contrôleur Admin.
+ */
+class Controller {
+/**
+ * Enregistre les hooks admin.
+ */
+public function hooks(): void {
+add_action( 'admin_menu', [ $this, 'register_menu' ] );
+add_action( 'admin_post_vsoa_import', [ $this, 'handle_import' ] );
+}
+
+/**
+ * Ajoute le menu principal.
+ */
+public function register_menu(): void {
+add_menu_page(
+'VSOA Widget',
+'VSOA Widget',
+'manage_options',
+'vsoa-widget',
+[ $this, 'render_page' ],
+'dashicons-database',
+65
+);
+}
+
+/**
+ * Affiche la page.
+ */
+public function render_page(): void {
+if ( ! current_user_can( 'manage_options' ) ) {
+return;
+}
+
+$storage   = new Storage();
+$rows_json = $storage->export_json();
+?>
+<div class="wrap">
+<h1><?php esc_html_e( 'VSOA Widget — Import/Export JSON', 'vsoa-widget' ); ?></h1>
+
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+<?php wp_nonce_field( 'vsoa_import_action' ); ?>
+<input type="hidden" name="action" value="vsoa_import" />
+<p><?php esc_html_e( 'Collez le JSON (format historique, tableau).', 'vsoa-widget' ); ?></p>
+<textarea name="vsoa_json" rows="12" class="large-text code"><?php echo esc_textarea( $rows_json ); ?></textarea>
+<p>
+<label>
+<input type="checkbox" name="vsoa_mode" value="merge" />
+<?php esc_html_e( 'Fusionner (ajout/mise à jour).', 'vsoa-widget' ); ?>
+</label>
+</p>
+<p>
+<button type="submit" class="button button-primary">
+<?php esc_html_e( 'Importer', 'vsoa-widget' ); ?>
+</button>
+<a class="button" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=vsoa_import&mode=delete' ), 'vsoa_import_action' ) ); ?>">
+<?php esc_html_e( 'Supprimer via JSON', 'vsoa-widget' ); ?>
+</a>
+<a class="button button-secondary" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=vsoa_import&mode=reset' ), 'vsoa_import_action' ) ); ?>">
+<?php esc_html_e( 'Reset complet', 'vsoa-widget' ); ?>
+</a>
+</p>
+</form>
+
+<h2><?php esc_html_e( 'Export JSON', 'vsoa-widget' ); ?></h2>
+<textarea readonly rows="12" class="large-text code"><?php echo esc_textarea( wp_json_encode( $storage->get_rows(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE ) ); ?></textarea>
+</div>
+<?php
+}
+
+/**
+ * Traitement de l'import.
+ */
+public function handle_import(): void {
+if ( ! current_user_can( 'manage_options' ) ) {
+wp_die( esc_html__( 'Permission refusée.', 'vsoa-widget' ) );
+}
+
+check_admin_referer( 'vsoa_import_action' );
+
+$mode = isset( $_REQUEST['mode'] ) ? sanitize_key( wp_unslash( (string) $_REQUEST['mode'] ) ) : ( isset( $_POST['vsoa_mode'] ) ? 'merge' : 'replace' );
+
+$storage = new Storage();
+try {
+if ( 'delete' === $mode ) {
+$storage->import_json( $this->get_json_input(), 'delete' );
+} elseif ( 'reset' === $mode ) {
+$storage->replace_all( [] );
+} else {
+$storage->import_json( $this->get_json_input(), $mode );
+}
+
+$message = __( 'Import effectué.', 'vsoa-widget' );
+} catch ( \InvalidArgumentException $exception ) {
+$message = $exception->getMessage();
+}
+
+wp_safe_redirect(
+add_query_arg(
+[
+'page'    => 'vsoa-widget',
+'message' => rawurlencode( $message ),
+],
+admin_url( 'admin.php' )
+)
+);
+exit;
+}
+
+/**
+ * Récupère le JSON soumis.
+ */
+private function get_json_input(): string {
+if ( isset( $_POST['vsoa_json'] ) ) {
+return (string) wp_unslash( $_POST['vsoa_json'] );
+}
+
+return '[]';
+}
+}

--- a/src/Admin/Controller.php
+++ b/src/Admin/Controller.php
@@ -1,132 +1,555 @@
 <?php
 /**
- * Gestion de l'interface administrateur (import/export, CRUD).
+ * Gestion de l'interface administrateur (import/export, CRUD, pricing, stats).
  *
  * @package Vsoa\Admin
  */
 
 namespace Vsoa\Admin;
 
+use Vsoa\Pricing\PricingManager;
+use Vsoa\Stats\StatsCollector;
 use Vsoa\Storage\Storage;
 
 /**
  * Contrôleur Admin.
  */
 class Controller {
-/**
- * Enregistre les hooks admin.
- */
-public function hooks(): void {
-add_action( 'admin_menu', [ $this, 'register_menu' ] );
-add_action( 'admin_post_vsoa_import', [ $this, 'handle_import' ] );
-}
+    /**
+     * Enregistre les hooks admin.
+     */
+    public function hooks(): void {
+        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+        add_action( 'admin_post_vsoa_import', [ $this, 'handle_import' ] );
+        add_action( 'admin_post_vsoa_row_save', [ $this, 'handle_row_save' ] );
+        add_action( 'admin_post_vsoa_row_delete', [ $this, 'handle_row_delete' ] );
+        add_action( 'admin_post_vsoa_price_update', [ $this, 'handle_price_update' ] );
+        add_action( 'admin_post_vsoa_stats_reset', [ $this, 'handle_stats_reset' ] );
+        add_action( 'admin_post_vsoa_stats_flush', [ $this, 'handle_stats_flush' ] );
+    }
 
-/**
- * Ajoute le menu principal.
- */
-public function register_menu(): void {
-add_menu_page(
-'VSOA Widget',
-'VSOA Widget',
-'manage_options',
-'vsoa-widget',
-[ $this, 'render_page' ],
-'dashicons-database',
-65
-);
-}
+    /**
+     * Ajoute le menu principal.
+     */
+    public function register_menu(): void {
+        add_menu_page(
+            'VSOA Widget',
+            'VSOA Widget',
+            'manage_options',
+            'vsoa-widget',
+            [ $this, 'render_page' ],
+            'dashicons-database',
+            65
+        );
+    }
 
-/**
- * Affiche la page.
- */
-public function render_page(): void {
-if ( ! current_user_can( 'manage_options' ) ) {
-return;
-}
+    /**
+     * Affiche la page.
+     */
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
 
-$storage   = new Storage();
-$rows_json = $storage->export_json();
-?>
-<div class="wrap">
-<h1><?php esc_html_e( 'VSOA Widget — Import/Export JSON', 'vsoa-widget' ); ?></h1>
+        $storage = new Storage();
+        $tabs    = [
+            'links'   => __( 'Gestion des liens', 'vsoa-widget' ),
+            'pricing' => __( 'Gestion des prix', 'vsoa-widget' ),
+            'stats'   => __( 'Statistiques', 'vsoa-widget' ),
+        ];
+        $active  = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( (string) $_GET['tab'] ) ) : 'links';
 
-<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-<?php wp_nonce_field( 'vsoa_import_action' ); ?>
-<input type="hidden" name="action" value="vsoa_import" />
-<p><?php esc_html_e( 'Collez le JSON (format historique, tableau).', 'vsoa-widget' ); ?></p>
-<textarea name="vsoa_json" rows="12" class="large-text code"><?php echo esc_textarea( $rows_json ); ?></textarea>
-<p>
-<label>
-<input type="checkbox" name="vsoa_mode" value="merge" />
-<?php esc_html_e( 'Fusionner (ajout/mise à jour).', 'vsoa-widget' ); ?>
-</label>
-</p>
-<p>
-<button type="submit" class="button button-primary">
-<?php esc_html_e( 'Importer', 'vsoa-widget' ); ?>
-</button>
-<a class="button" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=vsoa_import&mode=delete' ), 'vsoa_import_action' ) ); ?>">
-<?php esc_html_e( 'Supprimer via JSON', 'vsoa-widget' ); ?>
-</a>
-<a class="button button-secondary" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=vsoa_import&mode=reset' ), 'vsoa_import_action' ) ); ?>">
-<?php esc_html_e( 'Reset complet', 'vsoa-widget' ); ?>
-</a>
-</p>
-</form>
+        if ( ! isset( $tabs[ $active ] ) ) {
+            $active = 'links';
+        }
 
-<h2><?php esc_html_e( 'Export JSON', 'vsoa-widget' ); ?></h2>
-<textarea readonly rows="12" class="large-text code"><?php echo esc_textarea( wp_json_encode( $storage->get_rows(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE ) ); ?></textarea>
-</div>
-<?php
-}
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'VSOA Widget — Tableau de bord', 'vsoa-widget' ); ?></h1>
+            <?php $this->render_admin_notice(); ?>
+            <h2 class="nav-tab-wrapper">
+                <?php foreach ( $tabs as $slug => $label ) : ?>
+                    <?php
+                    $url   = add_query_arg(
+                        [
+                            'page' => 'vsoa-widget',
+                            'tab'  => $slug,
+                        ],
+                        admin_url( 'admin.php' )
+                    );
+                    $class = 'nav-tab' . ( $active === $slug ? ' nav-tab-active' : '' );
+                    ?>
+                    <a href="<?php echo esc_url( $url ); ?>" class="<?php echo esc_attr( $class ); ?>"><?php echo esc_html( $label ); ?></a>
+                <?php endforeach; ?>
+            </h2>
+            <div class="vsoa-admin-tab">
+                <?php
+                if ( 'pricing' === $active ) {
+                    $this->render_pricing_tab( $storage );
+                } elseif ( 'stats' === $active ) {
+                    $this->render_stats_tab();
+                } else {
+                    $this->render_links_tab( $storage );
+                }
+                ?>
+            </div>
+        </div>
+        <?php
+    }
 
-/**
- * Traitement de l'import.
- */
-public function handle_import(): void {
-if ( ! current_user_can( 'manage_options' ) ) {
-wp_die( esc_html__( 'Permission refusée.', 'vsoa-widget' ) );
-}
+    /**
+     * Onglet de gestion des liens.
+     */
+    private function render_links_tab( Storage $storage ): void {
+        $rows    = $storage->get_rows();
+        $edit_id = isset( $_GET['row'] ) ? sanitize_text_field( wp_unslash( (string) $_GET['row'] ) ) : '';
+        $edit    = $edit_id ? $storage->find_row( $edit_id ) : null;
+        $payload = $edit ? wp_json_encode( $edit, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE ) : '{}';
+        ?>
+        <div class="vsoa-links">
+            <h2><?php esc_html_e( 'Importer / Exporter', 'vsoa-widget' ); ?></h2>
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                <?php wp_nonce_field( 'vsoa_import_action' ); ?>
+                <input type="hidden" name="action" value="vsoa_import" />
+                <p><?php esc_html_e( 'Collez le JSON (format historique, tableau).', 'vsoa-widget' ); ?></p>
+                <textarea name="vsoa_json" rows="12" class="large-text code"><?php echo esc_textarea( $storage->export_json() ); ?></textarea>
+                <p>
+                    <label>
+                        <input type="checkbox" name="vsoa_mode" value="merge" />
+                        <?php esc_html_e( 'Fusionner (ajout/mise à jour).', 'vsoa-widget' ); ?>
+                    </label>
+                </p>
+                <p>
+                    <button type="submit" class="button button-primary"><?php esc_html_e( 'Importer', 'vsoa-widget' ); ?></button>
+                    <a class="button" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=vsoa_import&mode=delete' ), 'vsoa_import_action' ) ); ?>"><?php esc_html_e( 'Supprimer via JSON', 'vsoa-widget' ); ?></a>
+                    <a class="button button-secondary" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=vsoa_import&mode=reset' ), 'vsoa_import_action' ) ); ?>"><?php esc_html_e( 'Reset complet', 'vsoa-widget' ); ?></a>
+                </p>
+            </form>
 
-check_admin_referer( 'vsoa_import_action' );
+            <hr />
 
-$mode = isset( $_REQUEST['mode'] ) ? sanitize_key( wp_unslash( (string) $_REQUEST['mode'] ) ) : ( isset( $_POST['vsoa_mode'] ) ? 'merge' : 'replace' );
+            <h2><?php esc_html_e( 'Gestion des liens (CRUD)', 'vsoa-widget' ); ?></h2>
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="vsoa-row-form">
+                <?php wp_nonce_field( 'vsoa_row_save' ); ?>
+                <input type="hidden" name="action" value="vsoa_row_save" />
+                <p>
+                    <label for="vsoa_row_id"><strong><?php esc_html_e( 'Identifiant (id)', 'vsoa-widget' ); ?></strong></label><br />
+                    <input type="text" id="vsoa_row_id" name="vsoa_row_id" value="<?php echo esc_attr( $edit['id'] ?? '' ); ?>" class="regular-text" <?php echo $edit ? 'readonly' : ''; ?> required />
+                </p>
+                <p>
+                    <label for="vsoa_row_payload"><strong><?php esc_html_e( 'Payload JSON (sans le champ id)', 'vsoa-widget' ); ?></strong></label><br />
+                    <textarea id="vsoa_row_payload" name="vsoa_row_payload" rows="8" class="large-text code"><?php echo esc_textarea( $payload ); ?></textarea>
+                </p>
+                <p>
+                    <button type="submit" class="button button-primary"><?php echo $edit ? esc_html__( 'Mettre à jour la ligne', 'vsoa-widget' ) : esc_html__( 'Créer la ligne', 'vsoa-widget' ); ?></button>
+                    <?php if ( $edit ) : ?>
+                        <a class="button" href="<?php echo esc_url( remove_query_arg( 'row' ) ); ?>"><?php esc_html_e( 'Annuler', 'vsoa-widget' ); ?></a>
+                    <?php endif; ?>
+                </p>
+            </form>
 
-$storage = new Storage();
-try {
-if ( 'delete' === $mode ) {
-$storage->import_json( $this->get_json_input(), 'delete' );
-} elseif ( 'reset' === $mode ) {
-$storage->replace_all( [] );
-} else {
-$storage->import_json( $this->get_json_input(), $mode );
-}
+            <table class="widefat striped">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'ID', 'vsoa-widget' ); ?></th>
+                        <th><?php esc_html_e( 'Valeur', 'vsoa-widget' ); ?></th>
+                        <th><?php esc_html_e( 'Affiliate', 'vsoa-widget' ); ?></th>
+                        <th><?php esc_html_e( 'Offre', 'vsoa-widget' ); ?></th>
+                        <th><?php esc_html_e( 'Actions', 'vsoa-widget' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if ( empty( $rows ) ) : ?>
+                        <tr>
+                            <td colspan="5"><?php esc_html_e( 'Aucune ligne enregistrée pour le moment.', 'vsoa-widget' ); ?></td>
+                        </tr>
+                    <?php else : ?>
+                        <?php foreach ( $rows as $row ) : ?>
+                            <tr>
+                                <td><code><?php echo esc_html( (string) ( $row['id'] ?? '' ) ); ?></code></td>
+                                <td><?php echo esc_html( $this->extract_field( $row, [ 'data_value', 'data-value', 'value' ] ) ); ?></td>
+                                <td><?php echo esc_html( $this->extract_field( $row, [ 'data_aff', 'data-aff', 'affiliate' ] ) ); ?></td>
+                                <td><?php echo esc_html( $this->extract_field( $row, [ 'data_offer', 'data-offer', 'offer' ] ) ); ?></td>
+                                <td>
+                                    <?php
+                                    $edit_url = add_query_arg(
+                                        [
+                                            'page' => 'vsoa-widget',
+                                            'tab'  => 'links',
+                                            'row'  => $row['id'] ?? '',
+                                        ],
+                                        admin_url( 'admin.php' )
+                                    );
+                                    ?>
+                                    <a class="button button-small" href="<?php echo esc_url( $edit_url ); ?>"><?php esc_html_e( 'Modifier', 'vsoa-widget' ); ?></a>
+                                    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline-block;">
+                                        <?php wp_nonce_field( 'vsoa_row_delete' ); ?>
+                                        <input type="hidden" name="action" value="vsoa_row_delete" />
+                                        <input type="hidden" name="vsoa_row_id" value="<?php echo esc_attr( $row['id'] ?? '' ); ?>" />
+                                        <button type="submit" class="button button-small button-link-delete" onclick="return confirm('<?php echo esc_js( __( 'Supprimer cette ligne ?', 'vsoa-widget' ) ); ?>');"><?php esc_html_e( 'Supprimer', 'vsoa-widget' ); ?></button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
 
-$message = __( 'Import effectué.', 'vsoa-widget' );
-} catch ( \InvalidArgumentException $exception ) {
-$message = $exception->getMessage();
-}
+    /**
+     * Onglet pricing.
+     */
+    private function render_pricing_tab( Storage $storage ): void {
+        $rows            = $storage->get_rows();
+        $pricing_manager = new PricingManager();
+        $current_id      = isset( $_GET['row'] ) ? sanitize_text_field( wp_unslash( (string) $_GET['row'] ) ) : ( $rows[0]['id'] ?? '' );
+        $current_price   = $current_id ? $pricing_manager->get_price_for( $current_id ) : null;
+        $metadata        = (array) ( $current_price['metadata'] ?? [] );
+        $tiers           = isset( $metadata['tiers'] ) ? wp_json_encode( $metadata['tiers'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE ) : '[]';
+        $discounts       = isset( $metadata['discounts'] ) ? wp_json_encode( $metadata['discounts'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE ) : '[]';
+        ?>
+        <div class="vsoa-pricing">
+            <p><?php esc_html_e( 'Administrez les prix, devises, paliers et remises pour chaque ligne.', 'vsoa-widget' ); ?></p>
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="vsoa-price-form">
+                <?php wp_nonce_field( 'vsoa_price_update' ); ?>
+                <input type="hidden" name="action" value="vsoa_price_update" />
+                <p>
+                    <label for="vsoa_price_row"><strong><?php esc_html_e( 'Ligne cible', 'vsoa-widget' ); ?></strong></label><br />
+                    <select id="vsoa_price_row" name="vsoa_price_row" class="regular-text">
+                        <?php foreach ( $rows as $row ) : ?>
+                            <option value="<?php echo esc_attr( $row['id'] ?? '' ); ?>" <?php selected( $current_id, $row['id'] ?? '' ); ?>><?php echo esc_html( (string) ( $row['id'] ?? '' ) ); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </p>
+                <p>
+                    <label for="vsoa_price_amount"><strong><?php esc_html_e( 'Montant', 'vsoa-widget' ); ?></strong></label><br />
+                    <input type="number" step="0.01" min="0" id="vsoa_price_amount" name="vsoa_price_amount" value="<?php echo esc_attr( isset( $metadata['amount'] ) ? (string) $metadata['amount'] : '' ); ?>" class="regular-text" required />
+                </p>
+                <p>
+                    <label for="vsoa_price_currency"><strong><?php esc_html_e( 'Devise (ISO 4217)', 'vsoa-widget' ); ?></strong></label><br />
+                    <input type="text" maxlength="3" id="vsoa_price_currency" name="vsoa_price_currency" value="<?php echo esc_attr( isset( $metadata['currency'] ) ? (string) $metadata['currency'] : 'EUR' ); ?>" class="regular-text" required />
+                </p>
+                <p>
+                    <label for="vsoa_price_tiers"><strong><?php esc_html_e( 'Tiers (JSON)', 'vsoa-widget' ); ?></strong></label><br />
+                    <textarea id="vsoa_price_tiers" name="vsoa_price_tiers" rows="4" class="large-text code"><?php echo esc_textarea( $tiers ); ?></textarea>
+                </p>
+                <p>
+                    <label for="vsoa_price_discounts"><strong><?php esc_html_e( 'Remises (JSON)', 'vsoa-widget' ); ?></strong></label><br />
+                    <textarea id="vsoa_price_discounts" name="vsoa_price_discounts" rows="4" class="large-text code"><?php echo esc_textarea( $discounts ); ?></textarea>
+                </p>
+                <p>
+                    <button type="submit" class="button button-primary"><?php esc_html_e( 'Mettre à jour le prix', 'vsoa-widget' ); ?></button>
+                </p>
+            </form>
 
-wp_safe_redirect(
-add_query_arg(
-[
-'page'    => 'vsoa-widget',
-'message' => rawurlencode( $message ),
-],
-admin_url( 'admin.php' )
-)
-);
-exit;
-}
+            <h2><?php esc_html_e( 'Historique récent', 'vsoa-widget' ); ?></h2>
+            <?php if ( empty( $current_price['history'] ?? [] ) ) : ?>
+                <p><?php esc_html_e( 'Aucune modification de prix enregistrée.', 'vsoa-widget' ); ?></p>
+            <?php else : ?>
+                <table class="widefat striped">
+                    <thead>
+                        <tr>
+                            <th><?php esc_html_e( 'Date', 'vsoa-widget' ); ?></th>
+                            <th><?php esc_html_e( 'Ancien prix', 'vsoa-widget' ); ?></th>
+                            <th><?php esc_html_e( 'Nouveau prix', 'vsoa-widget' ); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ( $current_price['history'] as $entry ) : ?>
+                            <tr>
+                                <td><?php echo esc_html( (string) ( $entry['at'] ?? '' ) ); ?></td>
+                                <td><code><?php echo esc_html( wp_json_encode( $entry['old'] ?? [] ) ); ?></code></td>
+                                <td><code><?php echo esc_html( wp_json_encode( $entry['new'] ?? [] ) ); ?></code></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php endif; ?>
 
-/**
- * Récupère le JSON soumis.
- */
-private function get_json_input(): string {
-if ( isset( $_POST['vsoa_json'] ) ) {
-return (string) wp_unslash( $_POST['vsoa_json'] );
-}
+            <h2><?php esc_html_e( 'Résumé global', 'vsoa-widget' ); ?></h2>
+            <table class="widefat striped">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'ID', 'vsoa-widget' ); ?></th>
+                        <th><?php esc_html_e( 'Montant', 'vsoa-widget' ); ?></th>
+                        <th><?php esc_html_e( 'Devise', 'vsoa-widget' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ( $rows as $row ) :
+                        $price = $pricing_manager->get_price_for( (string) ( $row['id'] ?? '' ) );
+                        $meta  = (array) ( $price['metadata'] ?? [] );
+                        ?>
+                        <tr>
+                            <td><?php echo esc_html( (string) ( $row['id'] ?? '' ) ); ?></td>
+                            <td><?php echo esc_html( isset( $meta['amount'] ) ? (string) $meta['amount'] : '' ); ?></td>
+                            <td><?php echo esc_html( isset( $meta['currency'] ) ? (string) $meta['currency'] : '' ); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
 
-return '[]';
-}
+    /**
+     * Onglet statistiques.
+     */
+    private function render_stats_tab(): void {
+        $aggregates = StatsCollector::get_aggregates();
+        $queue_size = StatsCollector::get_queue_size();
+        ?>
+        <div class="vsoa-stats">
+            <p><?php esc_html_e( 'Aperçu des clics pseudonymisés (sans PII).', 'vsoa-widget' ); ?></p>
+            <p><?php printf( esc_html__( 'File en attente : %d événements.', 'vsoa-widget' ), absint( $queue_size ) ); ?></p>
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="margin-bottom:1em; display:inline-block;">
+                <?php wp_nonce_field( 'vsoa_stats_flush' ); ?>
+                <input type="hidden" name="action" value="vsoa_stats_flush" />
+                <button type="submit" class="button"><?php esc_html_e( 'Forcer l\'agrégation', 'vsoa-widget' ); ?></button>
+            </form>
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="margin-left:1em; display:inline-block;">
+                <?php wp_nonce_field( 'vsoa_stats_reset' ); ?>
+                <input type="hidden" name="action" value="vsoa_stats_reset" />
+                <button type="submit" class="button button-secondary" onclick="return confirm('<?php echo esc_js( __( 'Réinitialiser toutes les stats ?', 'vsoa-widget' ) ); ?>');"><?php esc_html_e( 'Reset statistiques', 'vsoa-widget' ); ?></button>
+            </form>
+
+            <table class="widefat striped" style="margin-top:1.5em;">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Identifiant pseudonymisé', 'vsoa-widget' ); ?></th>
+                        <th><?php esc_html_e( '24h', 'vsoa-widget' ); ?></th>
+                        <th><?php esc_html_e( '7 jours', 'vsoa-widget' ); ?></th>
+                        <th><?php esc_html_e( '30 jours', 'vsoa-widget' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if ( empty( $aggregates ) ) : ?>
+                        <tr>
+                            <td colspan="4"><?php esc_html_e( 'Aucune donnée agrégée pour le moment.', 'vsoa-widget' ); ?></td>
+                        </tr>
+                    <?php else : ?>
+                        <?php foreach ( $aggregates as $hash => $counts ) : ?>
+                            <tr>
+                                <td><code><?php echo esc_html( (string) $hash ); ?></code></td>
+                                <td><?php echo esc_html( isset( $counts['24h'] ) ? (string) $counts['24h'] : '0' ); ?></td>
+                                <td><?php echo esc_html( isset( $counts['7d'] ) ? (string) $counts['7d'] : '0' ); ?></td>
+                                <td><?php echo esc_html( isset( $counts['30d'] ) ? (string) $counts['30d'] : '0' ); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
+
+    /**
+     * Traitement de l'import.
+     */
+    public function handle_import(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permission refusée.', 'vsoa-widget' ) );
+        }
+
+        check_admin_referer( 'vsoa_import_action' );
+
+        $mode    = isset( $_REQUEST['mode'] ) ? sanitize_key( wp_unslash( (string) $_REQUEST['mode'] ) ) : ( isset( $_POST['vsoa_mode'] ) ? 'merge' : 'replace' );
+        $storage = new Storage();
+
+        try {
+            if ( 'delete' === $mode ) {
+                $storage->import_json( $this->get_json_input(), 'delete' );
+            } elseif ( 'reset' === $mode ) {
+                $storage->replace_all( [] );
+            } else {
+                $storage->import_json( $this->get_json_input(), $mode );
+            }
+
+            $message = __( 'Import effectué.', 'vsoa-widget' );
+        } catch ( \InvalidArgumentException $exception ) {
+            $message = $exception->getMessage();
+        }
+
+        $this->redirect_with_message( $message, 'links' );
+    }
+
+    /**
+     * Crée ou met à jour une ligne.
+     */
+    public function handle_row_save(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permission refusée.', 'vsoa-widget' ) );
+        }
+
+        check_admin_referer( 'vsoa_row_save' );
+
+        $id = isset( $_POST['vsoa_row_id'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['vsoa_row_id'] ) ) : '';
+
+        if ( '' === $id ) {
+            $this->redirect_with_message( __( 'Identifiant manquant.', 'vsoa-widget' ), 'links' );
+        }
+
+        $payload_raw = isset( $_POST['vsoa_row_payload'] ) ? wp_unslash( (string) $_POST['vsoa_row_payload'] ) : '{}';
+        $decoded     = json_decode( $payload_raw, true );
+
+        if ( null === $decoded || ! is_array( $decoded ) ) {
+            $this->redirect_with_message( __( 'Payload JSON invalide.', 'vsoa-widget' ), 'links', [ 'row' => $id ] );
+        }
+
+        unset( $decoded['id'] );
+
+        $storage = new Storage();
+        $storage->upsert_row( $id, $decoded );
+
+        $this->redirect_with_message( __( 'Ligne enregistrée.', 'vsoa-widget' ), 'links', [ 'row' => $id ] );
+    }
+
+    /**
+     * Supprime une ligne.
+     */
+    public function handle_row_delete(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permission refusée.', 'vsoa-widget' ) );
+        }
+
+        check_admin_referer( 'vsoa_row_delete' );
+
+        $id = isset( $_POST['vsoa_row_id'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['vsoa_row_id'] ) ) : '';
+
+        if ( '' !== $id ) {
+            ( new Storage() )->delete_row( $id );
+        }
+
+        $this->redirect_with_message( __( 'Ligne supprimée.', 'vsoa-widget' ), 'links' );
+    }
+
+    /**
+     * Met à jour un prix.
+     */
+    public function handle_price_update(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permission refusée.', 'vsoa-widget' ) );
+        }
+
+        check_admin_referer( 'vsoa_price_update' );
+
+        $id       = isset( $_POST['vsoa_price_row'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['vsoa_price_row'] ) ) : '';
+        $amount   = isset( $_POST['vsoa_price_amount'] ) ? (float) $_POST['vsoa_price_amount'] : 0.0;
+        $currency = isset( $_POST['vsoa_price_currency'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['vsoa_price_currency'] ) ) : '';
+        $tiers    = isset( $_POST['vsoa_price_tiers'] ) ? wp_unslash( (string) $_POST['vsoa_price_tiers'] ) : '[]';
+        $discount = isset( $_POST['vsoa_price_discounts'] ) ? wp_unslash( (string) $_POST['vsoa_price_discounts'] ) : '[]';
+
+        $tiers_decoded    = json_decode( $tiers, true );
+        $discount_decoded = json_decode( $discount, true );
+
+        if ( ! is_array( $tiers_decoded ) || ! is_array( $discount_decoded ) ) {
+            $this->redirect_with_message( __( 'Les champs tiers/remises doivent être du JSON valide.', 'vsoa-widget' ), 'pricing', [ 'row' => $id ] );
+        }
+
+        try {
+            ( new PricingManager() )->update_price_for(
+                $id,
+                [
+                    'amount'    => $amount,
+                    'currency'  => $currency,
+                    'tiers'     => $tiers_decoded,
+                    'discounts' => $discount_decoded,
+                ]
+            );
+            $message = __( 'Prix mis à jour.', 'vsoa-widget' );
+        } catch ( \InvalidArgumentException $exception ) {
+            $message = $exception->getMessage();
+        }
+
+        $this->redirect_with_message( $message, 'pricing', [ 'row' => $id ] );
+    }
+
+    /**
+     * Forçage de l'agrégation des stats.
+     */
+    public function handle_stats_flush(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permission refusée.', 'vsoa-widget' ) );
+        }
+
+        check_admin_referer( 'vsoa_stats_flush' );
+        StatsCollector::flush_queue();
+        $this->redirect_with_message( __( 'Agrégation exécutée.', 'vsoa-widget' ), 'stats' );
+    }
+
+    /**
+     * Reset complet des stats.
+     */
+    public function handle_stats_reset(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permission refusée.', 'vsoa-widget' ) );
+        }
+
+        check_admin_referer( 'vsoa_stats_reset' );
+        StatsCollector::reset();
+        $this->redirect_with_message( __( 'Statistiques réinitialisées.', 'vsoa-widget' ), 'stats' );
+    }
+
+    /**
+     * Récupère le JSON soumis.
+     */
+    private function get_json_input(): string {
+        if ( isset( $_POST['vsoa_json'] ) ) {
+            return (string) wp_unslash( $_POST['vsoa_json'] );
+        }
+
+        return '[]';
+    }
+
+    /**
+     * Affiche un message de confirmation.
+     */
+    private function render_admin_notice(): void {
+        if ( empty( $_GET['message'] ) ) {
+            return;
+        }
+
+        $message = sanitize_text_field( wp_unslash( rawurldecode( (string) $_GET['message'] ) ) );
+
+        printf( '<div class="notice notice-success"><p>%s</p></div>', esc_html( $message ) );
+    }
+
+    /**
+     * Redirige avec message.
+     *
+     * @param string               $message Message.
+     * @param string               $tab     Onglet cible.
+     * @param array<string,string> $extra   Params supplémentaires.
+     */
+    private function redirect_with_message( string $message, string $tab, array $extra = [] ): void {
+        $args = array_merge(
+            [
+                'page'    => 'vsoa-widget',
+                'tab'     => $tab,
+                'message' => $message,
+            ],
+            $extra
+        );
+
+        wp_safe_redirect( add_query_arg( $args, admin_url( 'admin.php' ) ) );
+        exit;
+    }
+
+    /**
+     * Extrait une valeur probable de ligne.
+     *
+     * @param array<string,mixed> $row  Ligne.
+     * @param array<int,string>   $keys Clés candidates.
+     */
+    private function extract_field( array $row, array $keys ): string {
+        foreach ( $keys as $key ) {
+            if ( isset( $row[ $key ] ) && is_scalar( $row[ $key ] ) ) {
+                return (string) $row[ $key ];
+            }
+        }
+
+        return '';
+    }
 }

--- a/src/Core/Loader.php
+++ b/src/Core/Loader.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Core loader qui initialise les modules du plugin.
+ *
+ * @package Vsoa\Core
+ */
+
+namespace Vsoa\Core;
+
+use Vsoa\API\RestController;
+use Vsoa\Admin\Controller as AdminController;
+use Vsoa\Frontend\Enqueue as FrontendEnqueue;
+use Vsoa\Stats\StatsCollector;
+
+/**
+ * Classe principale de chargement.
+ */
+class Loader {
+	/**
+	 * Initialise tous les hooks.
+	 */
+	public function init(): void {
+		if ( is_admin() ) {
+			( new AdminController() )->hooks();
+		}
+
+		add_action( 'rest_api_init', [ $this, 'register_rest' ] );
+		( new FrontendEnqueue() )->hooks();
+
+		add_action( 'init', [ $this, 'register_cron_events' ] );
+	}
+
+	/**
+	 * Déclare les routes REST.
+	 */
+	public function register_rest(): void {
+		( new RestController() )->register_routes();
+	}
+
+	/**
+	 * Enregistre les évènements cron nécessaires.
+	 */
+	public function register_cron_events(): void {
+		if ( ! wp_next_scheduled( 'vsoa_stats_flush' ) ) {
+			wp_schedule_event( time() + MINUTE_IN_SECONDS, 'hourly', 'vsoa_stats_flush' );
+		}
+
+		add_action( 'vsoa_stats_flush', [ StatsCollector::class, 'flush_queue' ] );
+	}
+}

--- a/src/Frontend/Enqueue.php
+++ b/src/Frontend/Enqueue.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Gestion du front-end : scripts et shortcode.
+ *
+ * @package Vsoa\Frontend
+ */
+
+namespace Vsoa\Frontend;
+
+/**
+ * Enqueue & Shortcode front.
+ */
+class Enqueue {
+/**
+ * Déclare les hooks.
+ */
+public function hooks(): void {
+add_action( 'wp_enqueue_scripts', [ $this, 'register_assets' ] );
+add_shortcode( 'vsoa_widget', [ $this, 'render_shortcode' ] );
+}
+
+/**
+ * Enregistre le script front minimal.
+ */
+public function register_assets(): void {
+wp_register_script(
+'vsoa-front',
+plugins_url( 'assets/js/vsoa-front.js', VSOA_PLUGIN_FILE ),
+[],
+VSOA_PLUGIN_VERSION,
+true
+);
+
+wp_enqueue_script( 'vsoa-front' );
+
+wp_localize_script(
+'vsoa-front',
+'VSOA_FRONT_CFG',
+[
+'rest' => [
+'namespace' => 'vsoa/v1',
+'root'      => esc_url_raw( rest_url() ),
+],
+]
+);
+}
+
+/**
+ * Shortcode principal.
+ *
+ * @param array<string, mixed> $atts Attributs.
+ */
+public function render_shortcode( array $atts ): string {
+$atts = shortcode_atts(
+[
+'value' => '',
+'aff'   => '',
+'offer' => '',
+],
+$atts,
+'vsoa_widget'
+);
+
+$value = sanitize_text_field( (string) $atts['value'] );
+$aff   = sanitize_text_field( (string) $atts['aff'] );
+$offer = sanitize_text_field( (string) $atts['offer'] );
+
+if ( '' === $value ) {
+return '';
+}
+
+$attributes = sprintf( ' data-value="%s"', esc_attr( $value ) );
+
+if ( '' !== $aff ) {
+$attributes .= sprintf( ' data-aff="%s"', esc_attr( $aff ) );
+}
+
+if ( '' !== $offer ) {
+$attributes .= sprintf( ' data-offer="%s"', esc_attr( $offer ) );
+}
+
+return '<span class="vsoa-item"' . $attributes . '></span>';
+}
+}

--- a/src/Obfuscation/Obfuscator.php
+++ b/src/Obfuscation/Obfuscator.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Utilitaires liés à l'obfuscation et aux tokens.
+ *
+ * @package Vsoa\Obfuscation
+ */
+
+namespace Vsoa\Obfuscation;
+
+/**
+ * Gère la génération/validation de jetons.
+ */
+class Obfuscator {
+private const TOKEN_OPTION = 'vsoa_obfuscation_secret';
+
+/**
+ * Génère un token signé.
+ */
+public function generate_token( string $value, int $ttl = 60 ): array {
+$secret = $this->get_secret();
+$expires = time() + max( 10, $ttl );
+
+$payload = [
+'value'   => $value,
+'expires' => $expires,
+];
+
+$signature = hash_hmac( 'sha256', wp_json_encode( $payload ), $secret );
+
+return [
+'token'     => base64_encode( wp_json_encode( $payload ) ),
+'signature' => $signature,
+'expires'   => $expires,
+];
+}
+
+/**
+ * Valide un token signé.
+ */
+public function validate_token( string $token, string $signature ): bool {
+$secret  = $this->get_secret();
+$decoded = json_decode( base64_decode( $token, true ), true );
+
+if ( ! is_array( $decoded ) ) {
+return false;
+}
+
+if ( empty( $decoded['value'] ) || empty( $decoded['expires'] ) ) {
+return false;
+}
+
+$expected = hash_hmac( 'sha256', wp_json_encode( $decoded ), $secret );
+
+if ( ! hash_equals( $expected, $signature ) ) {
+return false;
+}
+
+return (int) $decoded['expires'] >= time();
+}
+
+/**
+ * Retourne la clé secrète.
+ */
+private function get_secret(): string {
+$secret = get_option( self::TOKEN_OPTION );
+
+if ( ! $secret ) {
+$secret = bin2hex( random_bytes( 32 ) );
+update_option( self::TOKEN_OPTION, $secret, false );
+}
+
+return (string) $secret;
+}
+}

--- a/src/Pricing/PricingManager.php
+++ b/src/Pricing/PricingManager.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Gestion des prix et de l'audit.
+ *
+ * @package Vsoa\Pricing
+ */
+
+namespace Vsoa\Pricing;
+
+use Vsoa\Storage\Storage;
+use wpdb;
+
+/**
+ * Pricing manager.
+ */
+class PricingManager {
+	/**
+	 * Retourne le prix courant pour un ID.
+	 */
+	public function get_price_for( string $id ): ?array {
+		$row = ( new Storage() )->find_row( $id );
+
+		if ( null === $row ) {
+			return null;
+		}
+
+		return [
+			'base'     => $row['price'] ?? null,
+			'currency' => $row['currency'] ?? null,
+			'metadata' => $row['metadata']['pricing'] ?? [],
+			'history'  => $this->get_audit_log( $id ),
+		];
+	}
+
+	/**
+	 * Met à jour le prix d'une ligne.
+	 *
+	 * @param string               $id   Identifiant.
+	 * @param array<string, mixed> $data Données prix.
+	 */
+	public function update_price_for( string $id, array $data ): array {
+		$this->validate_price_payload( $data );
+
+		$storage = new Storage();
+		$row     = $storage->find_row( $id ) ?? [ 'id' => $id ];
+
+		$old_price                   = $row['metadata']['pricing'] ?? [];
+		$row['metadata']['pricing'] = [
+			'amount'    => (float) $data['amount'],
+			'currency'  => sanitize_text_field( (string) $data['currency'] ),
+			'tiers'     => $data['tiers'] ?? [],
+			'discounts' => $data['discounts'] ?? [],
+		];
+
+		$storage->upsert_row( $id, $row );
+
+		$this->log_price_change( $id, $old_price, $row['metadata']['pricing'] );
+
+		return $row['metadata']['pricing'];
+	}
+
+	/**
+	 * Valide le payload.
+	 *
+	 * @param array<string, mixed> $data Données.
+	 */
+	private function validate_price_payload( array $data ): void {
+		if ( empty( $data['amount'] ) || ! is_numeric( $data['amount'] ) ) {
+			throw new \InvalidArgumentException( 'Montant invalide.' );
+		}
+
+		if ( empty( $data['currency'] ) || 3 !== strlen( (string) $data['currency'] ) ) {
+			throw new \InvalidArgumentException( 'Devise invalide.' );
+		}
+
+		if ( isset( $data['discounts'] ) && ! is_array( $data['discounts'] ) ) {
+			throw new \InvalidArgumentException( 'Discounts doit être un tableau.' );
+		}
+
+		if ( isset( $data['tiers'] ) && ! is_array( $data['tiers'] ) ) {
+			throw new \InvalidArgumentException( 'Tiers doit être un tableau.' );
+		}
+	}
+
+	/**
+	 * Retourne l'historique.
+	 */
+	private function get_audit_log( string $id ): array {
+		global $wpdb;
+
+		$table = $this->get_table();
+
+		if ( ! $table ) {
+			return [];
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT old_price, new_price, changed_at FROM {$table} WHERE row_id = %s ORDER BY changed_at DESC LIMIT 10",
+				$id
+			),
+			ARRAY_A
+		);
+
+		return array_map(
+			static function ( $row ) {
+				return [
+					'old' => json_decode( (string) $row['old_price'], true ),
+					'new' => json_decode( (string) $row['new_price'], true ),
+					'at'  => $row['changed_at'],
+				];
+			},
+			$results
+		);
+	}
+
+	/**
+	 * Journalise le changement.
+	 */
+	private function log_price_change( string $id, array $old, array $new ): void {
+		global $wpdb;
+
+		$table = $this->get_table();
+
+		if ( ! $table ) {
+			return;
+		}
+
+		$wpdb->insert(
+			$table,
+			[
+				'row_id'     => $id,
+				'old_price'  => wp_json_encode( $old ),
+				'new_price'  => wp_json_encode( $new ),
+				'changed_by' => get_current_user_id(),
+				'changed_at' => current_time( 'mysql', true ),
+			]
+		);
+	}
+
+	/**
+	 * Retourne le nom de table si disponible.
+	 */
+	private function get_table(): ?string {
+		global $wpdb;
+
+		$table = $wpdb->prefix . Storage::PRICE_LOG_TABLE;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+
+		return $exists ? $table : null;
+	}
+}

--- a/src/Stats/StatsCollector.php
+++ b/src/Stats/StatsCollector.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Collecte et agrégation des statistiques.
+ *
+ * @package Vsoa\Stats
+ */
+
+namespace Vsoa\Stats;
+
+/**
+ * Stats collector.
+ */
+class StatsCollector {
+private const QUEUE_TRANSIENT = 'vsoa_stats_queue';
+private const AGGREGATE_OPTION = 'vsoa_stats_aggregates';
+
+/**
+ * Enfile un événement.
+ *
+ * @param string               $event   Type d'événement.
+ * @param array<string, mixed> $context Contexte.
+ */
+public static function track( string $event, array $context = [] ): void {
+if ( ! apply_filters( 'vsoa_stats_enabled', true ) ) {
+return;
+}
+
+$queue = (array) get_transient( self::QUEUE_TRANSIENT );
+$queue[] = [
+'event'   => $event,
+'context' => $context,
+'time'    => time(),
+];
+
+set_transient( self::QUEUE_TRANSIENT, $queue, HOUR_IN_SECONDS );
+}
+
+/**
+ * Flush la file et agrège.
+ */
+public static function flush_queue(): void {
+$queue = (array) get_transient( self::QUEUE_TRANSIENT );
+
+if ( empty( $queue ) ) {
+return;
+}
+
+delete_transient( self::QUEUE_TRANSIENT );
+
+$aggregates = self::get_aggregates();
+$now        = time();
+
+foreach ( $queue as $item ) {
+$row_id = isset( $item['context']['value'] ) ? self::hash_identifier( (string) $item['context']['value'] ) : 'generic';
+
+if ( ! isset( $aggregates[ $row_id ] ) ) {
+$aggregates[ $row_id ] = [];
+}
+
+$aggregates[ $row_id ][] = [
+'event' => $item['event'] ?? 'unknown',
+'time'  => $item['time'] ?? $now,
+];
+}
+
+update_option( self::AGGREGATE_OPTION, wp_json_encode( $aggregates ) );
+}
+
+/**
+ * Retourne les agrégats décodés.
+ */
+public static function get_aggregates(): array {
+$data = json_decode( (string) get_option( self::AGGREGATE_OPTION, '{}' ), true );
+
+if ( ! is_array( $data ) ) {
+return [];
+}
+
+$windowed = [];
+$now      = time();
+
+foreach ( $data as $row_id => $events ) {
+$windowed[ $row_id ] = [ '24h' => 0, '7d' => 0, '30d' => 0 ];
+
+foreach ( (array) $events as $event ) {
+$time = isset( $event['time'] ) ? (int) $event['time'] : $now;
+if ( $time >= $now - DAY_IN_SECONDS ) {
+$windowed[ $row_id ]['24h']++;
+}
+if ( $time >= $now - WEEK_IN_SECONDS ) {
+$windowed[ $row_id ]['7d']++;
+}
+if ( $time >= $now - MONTH_IN_SECONDS ) {
+$windowed[ $row_id ]['30d']++;
+}
+}
+}
+
+return $windowed;
+}
+
+/**
+ * Reset complet.
+ */
+public static function reset(): void {
+delete_transient( self::QUEUE_TRANSIENT );
+delete_option( self::AGGREGATE_OPTION );
+}
+
+/**
+ * Hash pseudonymisé.
+ */
+private static function hash_identifier( string $value ): string {
+$key = apply_filters( 'vsoa_stats_hash_key', wp_salt( 'vsoa-stats' ) );
+
+return hash_hmac( 'sha256', $value, (string) $key );
+}
+}

--- a/src/Stats/StatsCollector.php
+++ b/src/Stats/StatsCollector.php
@@ -108,6 +108,15 @@ delete_option( self::AGGREGATE_OPTION );
 }
 
 /**
+ * Retourne le nombre d'évènements en file.
+ */
+public static function get_queue_size(): int {
+$queue = get_transient( self::QUEUE_TRANSIENT );
+
+return is_array( $queue ) ? count( $queue ) : 0;
+}
+
+/**
  * Hash pseudonymisé.
  */
 private static function hash_identifier( string $value ): string {

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Gestion du stockage des lignes JSON et migrations.
+ *
+ * @package Vsoa\Storage
+ */
+
+namespace Vsoa\Storage;
+
+use wpdb;
+use WP_Error;
+
+/**
+ * Stockage principal en option WP (compat JSON) + audit pricing.
+ */
+class Storage {
+public const OPTION_KEY = 'vsoa_rows_json';
+public const VERSION_OPTION = 'vsoa_storage_version';
+public const PRICE_LOG_TABLE = 'vsoa_price_log';
+
+/**
+ * Installe ou met à jour la structure.
+ */
+public function install(): void {
+$this->maybe_create_option();
+$this->maybe_install_tables();
+update_option( self::VERSION_OPTION, '1.0.0', false );
+}
+
+/**
+ * Nettoie les données lors de la désinstallation.
+ */
+public function uninstall(): void {
+delete_option( self::OPTION_KEY );
+delete_option( self::VERSION_OPTION );
+
+global $wpdb;
+$table = $this->get_price_log_table();
+
+if ( $this->table_exists( $table ) ) {
+$wpdb->query( "DROP TABLE IF EXISTS {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+}
+}
+
+/**
+ * Retourne toutes les lignes JSON (format identique à l'historique).
+ */
+public function get_rows(): array {
+$json = (string) get_option( self::OPTION_KEY, '[]' );
+$data = json_decode( $json, true );
+
+return is_array( $data ) ? array_values( $data ) : [];
+}
+
+/**
+ * Export brut du JSON.
+ */
+public function export_json(): string {
+return (string) get_option( self::OPTION_KEY, '[]' );
+}
+
+/**
+ * Remplace l'intégralité du JSON (reset total).
+ *
+ * @param array<int, array<string, mixed>> $rows Rows.
+ */
+public function replace_all( array $rows ): void {
+update_option( self::OPTION_KEY, wp_json_encode( array_values( $rows ) ) );
+}
+
+/**
+ * Ajoute ou met à jour une ligne.
+ *
+ * @param string                       $id      Identifiant.
+ * @param array<string, mixed>         $payload Données.
+ */
+public function upsert_row( string $id, array $payload ): void {
+$rows  = $this->get_rows();
+$found = false;
+
+foreach ( $rows as $index => $row ) {
+if ( isset( $row['id'] ) && (string) $row['id'] === $id ) {
+$rows[ $index ] = $this->merge_row( $row, $payload, $id );
+$found          = true;
+break;
+}
+}
+
+if ( ! $found ) {
+$payload['id'] = $id;
+$rows[]        = $this->sanitize_row( $payload );
+}
+
+$this->replace_all( $rows );
+}
+
+/**
+ * Supprime une ligne.
+ */
+public function delete_row( string $id ): void {
+$rows = array_filter(
+$this->get_rows(),
+static fn ( $row ) => ! ( isset( $row['id'] ) && (string) $row['id'] === $id )
+);
+
+$this->replace_all( array_values( $rows ) );
+}
+
+/**
+ * Import JSON : ajoute/maj/supprime selon options.
+ *
+ * @param string $json JSON reçu.
+ * @param string $mode Mode (replace|merge|delete).
+ *
+ * @return array<string, int>
+ */
+public function import_json( string $json, string $mode = 'replace' ): array {
+$data = json_decode( $json, true );
+
+if ( ! is_array( $data ) ) {
+throw new \InvalidArgumentException( 'JSON invalide (tableau attendu).' );
+}
+
+if ( 'replace' === $mode ) {
+$this->replace_all( $this->sanitize_rows( $data ) );
+
+return [
+'inserted' => count( $data ),
+'updated'  => 0,
+'deleted'  => 0,
+];
+}
+
+$inserted = 0;
+$updated  = 0;
+$deleted  = 0;
+
+if ( 'delete' === $mode ) {
+foreach ( $data as $row ) {
+if ( isset( $row['id'] ) ) {
+$this->delete_row( (string) $row['id'] );
+$deleted++;
+}
+}
+} else {
+foreach ( $data as $row ) {
+if ( empty( $row['id'] ) ) {
+continue;
+}
+
+$before = $this->find_row( (string) $row['id'] );
+$this->upsert_row( (string) $row['id'], (array) $row );
+
+if ( null === $before ) {
+$inserted++;
+} else {
+$updated++;
+}
+}
+}
+
+return [
+'inserted' => $inserted,
+'updated'  => $updated,
+'deleted'  => $deleted,
+];
+}
+
+/**
+ * Recherche une ligne par ID.
+ */
+public function find_row( string $id ): ?array {
+foreach ( $this->get_rows() as $row ) {
+if ( isset( $row['id'] ) && (string) $row['id'] === $id ) {
+return $row;
+}
+}
+
+return null;
+}
+
+/**
+ * Fusionne et nettoie les données.
+ */
+private function merge_row( array $existing, array $payload, string $id ): array {
+$payload['id'] = $id;
+
+return $this->sanitize_row( array_merge( $existing, $payload ) );
+}
+
+/**
+ * Sanitize une ligne.
+ */
+private function sanitize_row( array $row ): array {
+foreach ( $row as $key => $value ) {
+if ( is_string( $value ) ) {
+$row[ $key ] = sanitize_text_field( $value );
+} elseif ( is_array( $value ) ) {
+$row[ $key ] = $this->sanitize_row( $value );
+}
+}
+
+return $row;
+}
+
+/**
+ * Sanitize une liste de lignes.
+ *
+ * @param array<int, array<string, mixed>> $rows Rows.
+ */
+private function sanitize_rows( array $rows ): array {
+return array_map( fn ( $row ) => $this->sanitize_row( (array) $row ), $rows );
+}
+
+/**
+ * Crée l'option de stockage si nécessaire.
+ */
+private function maybe_create_option(): void {
+if ( null === get_option( self::OPTION_KEY, null ) ) {
+add_option( self::OPTION_KEY, '[]', '', false );
+}
+}
+
+/**
+ * Crée la table d'audit de prix si besoin.
+ */
+private function maybe_install_tables(): void {
+global $wpdb;
+
+$table_name = $this->get_price_log_table();
+
+if ( $this->table_exists( $table_name ) ) {
+return;
+}
+
+require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+$charset_collate = $wpdb->get_charset_collate();
+$sql             = "CREATE TABLE {$table_name} (
+id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+row_id VARCHAR(190) NOT NULL,
+old_price LONGTEXT NULL,
+new_price LONGTEXT NOT NULL,
+changed_by BIGINT UNSIGNED NULL,
+changed_at DATETIME NOT NULL,
+PRIMARY KEY  (id),
+KEY row_id (row_id)
+) {$charset_collate};";
+
+dbDelta( $sql );
+}
+
+/**
+ * Vérifie l'existence d'une table.
+ */
+private function table_exists( string $table ): bool {
+global $wpdb;
+
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+return (bool) $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+}
+
+/**
+ * Retourne le nom fully-qualified de la table de log.
+ */
+private function get_price_log_table(): string {
+global $wpdb;
+
+return $wpdb->prefix . self::PRICE_LOG_TABLE;
+}
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Vsoa\Tests;
+
+use Brain\Monkey;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+abstract class TestCase extends PHPUnitTestCase {
+protected function setUp(): void {
+parent::setUp();
+Monkey\setUp();
+}
+
+protected function tearDown(): void {
+Monkey\tearDown();
+parent::tearDown();
+}
+}

--- a/tests/Unit/RestControllerTest.php
+++ b/tests/Unit/RestControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Vsoa\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use Vsoa\API\RestController;
+use Vsoa\Tests\TestCase;
+use WP_REST_Request;
+
+class RestControllerTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		Functions\when( 'sanitize_text_field' )->alias(
+			fn ( $value ) => $value
+		);
+
+		Functions\when( 'apply_filters' )->alias(
+			function ( $tag, $value ) {
+				return func_num_args() >= 3 ? func_get_arg( 2 ) : $value;
+			}
+		);
+
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\when( 'has_filter' )->justReturn( false );
+	}
+
+	public function test_resolve_offer_requires_value(): void {
+		$controller = new RestController();
+		$request    = new WP_REST_Request();
+
+		$response = $controller->resolve_offer( $request );
+
+		$this->assertInstanceOf( '\WP_Error', $response );
+	}
+
+	public function test_resolve_offer_returns_token(): void {
+		$controller = new RestController();
+		$request    = new WP_REST_Request( [ 'data_value' => 'offer1' ] );
+
+		$response = $controller->resolve_offer( $request );
+
+		$this->assertInstanceOf( '\WP_REST_Response', $response );
+		$this->assertArrayHasKey( 'token', $response->data );
+		$this->assertSame( MINUTE_IN_SECONDS, $response->data['ttl'] );
+	}
+}

--- a/tests/Unit/StorageTest.php
+++ b/tests/Unit/StorageTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Vsoa\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use Vsoa\Storage\Storage;
+use Vsoa\Tests\TestCase;
+
+class StorageTest extends TestCase {
+private array $options;
+
+protected function setUp(): void {
+parent::setUp();
+
+$this->options = [];
+
+Functions\when( 'get_option' )->alias( function ( $name, $default = false ) {
+return $this->options[ $name ] ?? $default;
+} );
+
+Functions\when( 'update_option' )->alias( function ( $name, $value ) {
+$this->options[ $name ] = $value;
+return true;
+} );
+
+Functions\when( 'add_option' )->alias( function ( $name, $value ) {
+if ( isset( $this->options[ $name ] ) ) {
+return false;
+}
+$this->options[ $name ] = $value;
+return true;
+} );
+
+Functions\when( 'delete_option' )->alias( function ( $name ) {
+unset( $this->options[ $name ] );
+return true;
+} );
+}
+
+public function test_replace_and_export(): void {
+$storage = new Storage();
+$rows    = [ [ 'id' => 'a', 'label' => 'A' ], [ 'id' => 'b', 'label' => 'B' ] ];
+
+$storage->replace_all( $rows );
+
+$this->assertSame( $rows, $storage->get_rows() );
+$this->assertSame( wp_json_encode( $rows ), $storage->export_json() );
+}
+
+public function test_import_merge_and_delete(): void {
+$storage = new Storage();
+
+$storage->import_json( wp_json_encode( [ [ 'id' => 'a', 'label' => 'A' ] ] ) );
+
+$result = $storage->import_json( wp_json_encode( [ [ 'id' => 'b', 'label' => 'B' ] ] ), 'merge' );
+
+$this->assertSame( 1, $result['inserted'] );
+$this->assertSame( 0, $result['updated'] );
+
+$result = $storage->import_json( wp_json_encode( [ [ 'id' => 'a', 'label' => 'A+' ] ] ), 'merge' );
+$this->assertSame( 1, $result['updated'] );
+
+$result = $storage->import_json( wp_json_encode( [ [ 'id' => 'b' ] ] ), 'delete' );
+$this->assertSame( 1, $result['deleted'] );
+}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,118 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+class WP_REST_Request {
+private array $params;
+private array $json;
+private string $body;
+
+public function __construct( array $params = [], array $json = [], string $body = '' ) {
+$this->params = $params;
+$this->json   = $json;
+$this->body   = $body;
+}
+
+public function get_param( string $key ) {
+return $this->params[ $key ] ?? null;
+}
+
+public function get_json_params(): array {
+return $this->json;
+}
+
+public function get_body(): string {
+return $this->body;
+}
+
+public function offsetGet( $offset ) {
+return $this->params[ $offset ] ?? null;
+}
+}
+}
+
+if ( ! class_exists( 'WP_REST_Response' ) ) {
+class WP_REST_Response {
+public function __construct( public $data = null, public int $status = 200 ) {}
+}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+class WP_Error {
+public function __construct( public string $code, public string $message, public array $data = [] ) {}
+}
+}
+
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
+
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+	define( 'WEEK_IN_SECONDS', 604800 );
+}
+
+if ( ! defined( 'MONTH_IN_SECONDS' ) ) {
+	define( 'MONTH_IN_SECONDS', 2592000 );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0 ) {
+		return json_encode( $data, $options );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ) {
+		return is_string( $value ) ? trim( $value ) : $value;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $value ) {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $value ) );
+	}
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4() {
+		return '00000000-0000-4000-8000-000000000000';
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+	function esc_html__( $text, $domain = null ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_html_e' ) ) {
+	function esc_html_e( $text, $domain = null ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+		echo $text;
+	}
+}
+
+if ( ! function_exists( 'esc_textarea' ) ) {
+	function esc_textarea( $text ) {
+		return $text;
+	}
+}


### PR DESCRIPTION
## Summary
- add a defensive fallback when generating resolve tokens to avoid calling wp_generate_uuid4 when it is unavailable

## Testing
- find . -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d92be7b3dc8324b2d1cdcfb945e2e7